### PR TITLE
pkg/config: add documentation and public types

### DIFF
--- a/Documentation/devel/config.md
+++ b/Documentation/devel/config.md
@@ -1,0 +1,21 @@
+# Configuration
+
+This projects defines a stable configuration interchange format in order for Ignition (or other provisioning systems) to persist LUKS volume parameters and for Cryptagent to retrieve them on reboots.
+
+Configuration files are JSON-based and strictly type-versioned, in order to ensure compatibility across versions and to ease manual inspection.
+
+# Paths
+
+Configuration for Cryptagent is rooted at `/boot/etc/coreos-cryptagent/`. Such directory would not exist on systems without encrypted volumes.
+After a cryptsetup volume is created, its configuration needs to be stored under `/boot/etc/cryptsetup-agent/dev/`.
+
+In particular, each encrypted device will get a configuration directory at `/boot/etc/cryptsetup-agent/dev/$DEVNAME/` containing a `volume.json` and `$N.json`, where:
+ * `$DEVNAME` is the `systemd-escape --path` encoded path of the user-specified encrypted device.
+ * `$N` is currently hardcoded to 0.
+ * `volume.json` contains volume configuration parameters.
+ * `$N.json` contains parameters for keyslot number `$N` (currently only keyslot 0 is available).
+ * configuration files are valid JSON documents, whose format is specified below.
+
+# Schemas
+
+TODO(lucab): add JSON schema for all public `pkg/config` structs.

--- a/Documentation/devel/config.md
+++ b/Documentation/devel/config.md
@@ -1,6 +1,6 @@
 # Configuration
 
-This projects defines a stable configuration interchange format in order for Ignition (or other provisioning systems) to persist LUKS volume parameters and for Cryptagent to retrieve them on reboots.
+This project defines a stable configuration format in order for Ignition (or other provisioning systems) to persist LUKS volume parameters and for Cryptagent to retrieve them on reboots.
 
 Configuration files are JSON-based and strictly type-versioned, in order to ensure compatibility across versions and to ease manual inspection.
 
@@ -19,3 +19,7 @@ In particular, each encrypted device will get a configuration directory at `/boo
 # Schemas
 
 TODO(lucab): add JSON schema for all public `pkg/config` structs.
+
+# Library usage
+
+Go programs can directly manipulate Cryptagent configuration via public types exposed by the `pkg/config` package in this repository.

--- a/pkg/config/azurevault.go
+++ b/pkg/config/azurevault.go
@@ -1,0 +1,33 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// TODO(lucab): double-check, stabilize and make this public.
+
+// AzureVaultV1 is the v1 configuration for an Azure Vault provider.
+type azureVaultV1 struct {
+	BaseURL             string                    `json:"baseURL"`
+	EncryptionAlgorithm string                    `json:"encryptionAlgorithm"`
+	KeyName             string                    `json:"keyName"`
+	KeyVersion          string                    `json:"keyVersion"`
+	Ciphertext          string                    `json:"ciphertext"`
+	PasswordAuth        *azureVaultV1PasswordAuth `json:"passwordAuth"`
+}
+
+// AzureVaultV1PasswordAuth is the password authentication stanza for AzureVaultV1.
+type azureVaultV1PasswordAuth struct {
+	AppID    string `json:"appID"`
+	Password string `json:"password"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,123 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config contains all configuration types for data interchange with
+// coreos-cryptagent.
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"path/filepath"
+)
+
+const (
+	// BaseConfigDir is the path of the base directory storing coreos-cryptagent config.
+	BaseConfigDir = "/boot/etc/coreos-cryptagent/"
+)
+
+var (
+	// DevConfigDir is the base directory for devices/volumes configuration files.
+	DevConfigDir = filepath.Join(BaseConfigDir, "dev")
+)
+
+// VolumeKind is an enum of volume kinds.
+type VolumeKind uint
+
+const (
+	// VolumeInvalid is the default invalid value for volume kind.
+	VolumeInvalid VolumeKind = iota
+	// VolumeCryptsetupLUKS1V1 represents a cryptsetup-LUKS1 (v1) volume config.
+	VolumeCryptsetupLUKS1V1
+)
+
+// UnmarshalJSON is part of the json.Unmarshaler interface.
+func (vk *VolumeKind) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "CryptsetupLUKS1V1":
+		*vk = VolumeCryptsetupLUKS1V1
+	default:
+		return errors.New("unknown kind")
+	}
+
+	return nil
+}
+
+// MarshalJSON is part of the json.Marshaler interface.
+func (vk VolumeKind) MarshalJSON() ([]byte, error) {
+	var s string
+	switch vk {
+	case VolumeCryptsetupLUKS1V1:
+		s = "CryptsetupLUKS1V1"
+	default:
+		return nil, errors.New("unknown kind")
+	}
+
+	return json.Marshal(s)
+}
+
+// ProviderKind is an enum of provider kinds.
+type ProviderKind int
+
+const (
+	// ProviderInvalid is the nil value for ProviderKind
+	ProviderInvalid ProviderKind = iota
+	// ProviderContentV1 represents a plain Content (v1) config
+	ProviderContentV1
+	// ProviderAzureVaultV1 represents an Azure Vault (v1) config
+	ProviderAzureVaultV1
+	// ProviderHcVaultV1 represents an HashiCorp Vault (v1) config
+	ProviderHcVaultV1
+)
+
+// UnmarshalJSON is part of the json.Unmarshaler interface.
+func (vk *ProviderKind) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "ContentV1":
+		*vk = ProviderContentV1
+	case "AzureVaultV1":
+		return errors.New("azure-vault unimplemented")
+	case "HcVaultV1":
+		return errors.New("hc-vault unimplemented")
+	default:
+		return errors.New("unknown kind")
+	}
+
+	return nil
+}
+
+// MarshalJSON is part of the json.Marshaler interface.
+func (vk ProviderKind) MarshalJSON() ([]byte, error) {
+	var s string
+	switch vk {
+	case ProviderContentV1:
+		s = "ContentV1"
+	case ProviderAzureVaultV1:
+		return nil, errors.New("azure-vault unimplemented")
+	case ProviderHcVaultV1:
+		return nil, errors.New("hc-vault unimplemented")
+	default:
+		return nil, errors.New("unknown kind")
+	}
+
+	return json.Marshal(s)
+}

--- a/pkg/config/content.go
+++ b/pkg/config/content.go
@@ -1,0 +1,35 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// ContentV1 is the v1 configuration for a generic remote content provider.
+type ContentV1 struct {
+	Source   string             `json:"source"`
+	Timeouts *ContentV1Timeouts `json:"timeouts,omitempty"`
+	//TODO(lucab): specify this better
+	CertificateAuthorities []ContentV1CertAuth `json:"certificateAuthorities,omitempty"`
+}
+
+// ContentV1Timeouts records HTTPS client timeouts
+type ContentV1Timeouts struct {
+	HTTPResponseHeaders int `json:"httpResponseHeaders"`
+	HTTPTotal           int `json:"httpTotal"`
+}
+
+// ContentV1CertAuth records HTTPS client custom CAs
+type ContentV1CertAuth struct {
+	//TODO(lucab): store PEM here? Or just a path?
+	Authority string `json:"authority"`
+}

--- a/pkg/config/content_test.go
+++ b/pkg/config/content_test.go
@@ -1,0 +1,38 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProviderJSONUmarshal(t *testing.T) {
+	test := `
+{
+  "kind": "ContentV1",
+  "value": {
+    "source": "https://localhost/key.txt"
+  }
+}
+`
+	var pj ProviderJSON
+	err := json.NewDecoder(strings.NewReader(test)).Decode(&pj)
+	if err != nil {
+		t.Fatalf("unexpected error %q", err)
+	}
+
+}

--- a/pkg/config/provider.go
+++ b/pkg/config/provider.go
@@ -1,0 +1,56 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// ProviderJSON is the top-level configuration container for a provider.
+type ProviderJSON struct {
+	Kind  ProviderKind `json:"kind"`
+	Value interface{}  `json:"value"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (pj *ProviderJSON) UnmarshalJSON(b []byte) error {
+	type tmps struct {
+		Kind  ProviderKind     `json:"kind"`
+		Value *json.RawMessage `json:"value"`
+	}
+	var tmp tmps
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+
+	switch tmp.Kind {
+	case ProviderContentV1:
+		var v ContentV1
+		if err := json.Unmarshal(*tmp.Value, &v); err != nil {
+			return err
+		}
+		pj.Kind = tmp.Kind
+		pj.Value = v
+	case ProviderAzureVaultV1:
+		return errors.New("azure-vault unimplemented")
+	case ProviderHcVaultV1:
+		return errors.New("hc-vault unimplemented")
+	default:
+		return errors.New("unknown kind")
+	}
+
+	return nil
+}

--- a/pkg/config/volume.go
+++ b/pkg/config/volume.go
@@ -1,0 +1,60 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// VolumeJSON is the top-level configuration container for an encrypted volume.
+type VolumeJSON struct {
+	Kind  VolumeKind  `json:"kind"`
+	Value interface{} `json:"value"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (vj *VolumeJSON) UnmarshalJSON(b []byte) error {
+	type tmps struct {
+		Kind  VolumeKind       `json:"kind"`
+		Value *json.RawMessage `json:"value"`
+	}
+	var tmp tmps
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+
+	switch tmp.Kind {
+	case VolumeCryptsetupLUKS1V1:
+		var v CryptsetupLUKS1V1
+		if err := json.Unmarshal(*tmp.Value, &v); err != nil {
+			return err
+		}
+		vj.Kind = tmp.Kind
+		vj.Value = v
+
+	default:
+		return errors.New("unknown kind")
+	}
+
+	return nil
+}
+
+// CryptsetupLUKS1V1 represents a cryptsetup-LUKS1 volume.
+type CryptsetupLUKS1V1 struct {
+	Name           string `json:"name"`
+	Device         string `json:"device"`
+	DisableDiscard *bool  `json:"disableDiscard,omitempty"`
+}

--- a/pkg/config/volume_test.go
+++ b/pkg/config/volume_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVolumeJSONUmarshal(t *testing.T) {
+	test := `
+{
+  "kind": "CryptsetupLUKS1V1",
+  "value": {
+    "name": "volName",
+    "device": "/dev/null",
+    "disableDiscard": true
+  }
+}
+`
+	var v VolumeJSON
+	err := json.NewDecoder(strings.NewReader(test)).Decode(&v)
+	if err != nil {
+		t.Fatalf("unexpected error %q", err)
+	}
+
+}


### PR DESCRIPTION
This contains an overview on configuration and data interchange between ignition and cryptagent, as well as public types which can be consumed by other Go programs.

Note: few fields are not yet final, JSON schemas will be added once everything is set.